### PR TITLE
Improve wallet support - logging in, logging out, displaying wallet status

### DIFF
--- a/src/components/AccountDetails/index.tsx
+++ b/src/components/AccountDetails/index.tsx
@@ -9,7 +9,7 @@ import { shortenAddress } from '../../utils'
 import { AutoRow } from '../Row'
 import Copy from './Copy'
 import Transaction from './Transaction'
-import { SUPPORTED_WALLETS } from '../../constants'
+import { SUPPORTED_WALLETS, UserWallet } from '../../constants'
 import { ReactComponent as Close } from '../../assets/images/x.svg'
 import { getEtherscanLink } from '../../utils'
 import { injected, walletconnect, walletlink, fortmatic, portis, hmy } from '../../connectors'
@@ -242,8 +242,8 @@ export default function AccountDetails({
 
     let name = '';
 
-    if (userWallet !== '') {
-      switch (userWallet.toLowerCase()) {
+    if (userWallet && userWallet.type != null && userWallet.type !== '') {
+      switch (userWallet.type.toLowerCase()) {
         case 'onewallet':
           name = 'OneWallet';
           break;
@@ -286,7 +286,7 @@ export default function AccountDetails({
 
     connector && connector.signOut()
     .then(() => {
-      setUserWallet('');
+      setUserWallet({} as UserWallet);
       toggleWalletModal();
     })
     .catch(error => {

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -141,7 +141,7 @@ export default function WalletModal({
 
   const [active, setActive] = useState<boolean>()
 
-  const [, setUserWallet] = useUserWallet()
+  const [userWallet, setUserWallet] = useUserWallet()
 
   const walletModalOpen = useWalletModalOpen()
   const toggleWalletModal = useWalletModalToggle()
@@ -329,7 +329,7 @@ export default function WalletModal({
         </UpperSection>
       )
     }
-    if (account && walletView === WALLET_VIEWS.ACCOUNT) {
+    if (userWallet !== '' && account && walletView === WALLET_VIEWS.ACCOUNT) {
       return (
         <AccountDetails
           toggleWalletModal={toggleWalletModal}

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -5,6 +5,7 @@ import { isMobile } from 'react-device-detect'
 import { UnsupportedChainIdError, useWeb3React } from '@web3-react/core'
 import usePrevious from '../../hooks/usePrevious'
 import { useWalletModalOpen, useWalletModalToggle } from '../../state/application/hooks'
+import { UserWallet } from '../../constants'
 
 import Modal from '../Modal'
 import AccountDetails from '../AccountDetails'
@@ -197,10 +198,16 @@ export default function WalletModal({
 
     connector && connector.signIn()
     .then(() => {
+      let wallet: UserWallet = {
+        type: connector.sessionType,
+        address: connector.base16Address,
+        bech32Address: connector.address
+      };
+
       setPendingError(false);
       setAccount(connector.address);
       setActive(true);
-      setUserWallet(connector.sessionType);
+      setUserWallet(wallet);
       setWalletView(WALLET_VIEWS.ACCOUNT);
       //toggleWalletModal();
     })
@@ -329,7 +336,7 @@ export default function WalletModal({
         </UpperSection>
       )
     }
-    if (userWallet !== '' && account && walletView === WALLET_VIEWS.ACCOUNT) {
+    if (userWallet && userWallet.address && walletView === WALLET_VIEWS.ACCOUNT) {
       return (
         <AccountDetails
           toggleWalletModal={toggleWalletModal}

--- a/src/components/WalletModal/index.tsx
+++ b/src/components/WalletModal/index.tsx
@@ -20,6 +20,8 @@ import { WalletConnectConnector } from '@web3-react/walletconnect-connector'
 //import { AbstractConnector } from '@web3-react/abstract-connector'
 import { AbstractWallet } from '../../wallets/AbstractWallet';
 
+import {useUserWallet} from '../../state/user/hooks'
+
 const CloseIcon = styled.div`
   position: absolute;
   right: 1rem;
@@ -126,7 +128,7 @@ export default function WalletModal({
   ENSName?: string
 }) {
   // important that these are destructed from the account-specific web3-react context
-  const { active, account, connector, error } = useWeb3React()
+  const { connector, error } = useWeb3React()
   //const { active, account, connector, activate, error } = useWeb3React()
 
   const [walletView, setWalletView] = useState(WALLET_VIEWS.ACCOUNT)
@@ -134,6 +136,12 @@ export default function WalletModal({
   const [pendingWallet, setPendingWallet] = useState<AbstractWallet | undefined>()
 
   const [pendingError, setPendingError] = useState<boolean>()
+
+  const [account, setAccount] = useState<string | null>()
+
+  const [active, setActive] = useState<boolean>()
+
+  const [, setUserWallet] = useUserWallet()
 
   const walletModalOpen = useWalletModalOpen()
   const toggleWalletModal = useWalletModalToggle()
@@ -190,8 +198,11 @@ export default function WalletModal({
     connector && connector.signIn()
     .then(() => {
       setPendingError(false);
+      setAccount(connector.address);
+      setActive(true);
+      setUserWallet(connector.sessionType);
       setWalletView(WALLET_VIEWS.ACCOUNT);
-      toggleWalletModal();
+      //toggleWalletModal();
     })
     .catch(error => {
       setPendingError(true)

--- a/src/components/Web3Status/index.tsx
+++ b/src/components/Web3Status/index.tsx
@@ -19,6 +19,8 @@ import { TransactionDetails } from '../../state/transactions/reducer'
 import { shortenAddress } from '../../utils'
 import { ButtonSecondary } from '../Button'
 
+import {useUserWallet} from '../../state/user/hooks'
+
 import Identicon from '../Identicon'
 import Loader from '../Loader'
 
@@ -180,7 +182,9 @@ function Web3StatusInner() {
   const hasSocks = useHasSocks()
   const toggleWalletModal = useWalletModalToggle()
 
-  if (account) {
+  const [userWallet,] = useUserWallet()
+
+  if (userWallet && userWallet.address) {
     return (
       <Web3StatusConnected id="web3-status-connected" onClick={toggleWalletModal} pending={hasPendingTransactions}>
         {hasPendingTransactions ? (
@@ -190,7 +194,7 @@ function Web3StatusInner() {
         ) : (
           <>
             {hasSocks ? SOCK : null}
-            <Text>{ENSName || shortenAddress(account)}</Text>
+            <Text>{ENSName || shortenAddress(userWallet.address)}</Text>
           </>
         )}
         {!hasPendingTransactions && connector && <StatusIcon connector={connector} />}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -66,6 +66,12 @@ export const PINNED_PAIRS: { readonly [chainId in typeof ChainID]?: [Token, Toke
   ]
 }
 
+export interface UserWallet {
+  type: string;
+  address: string | null;
+  bech32Address: string | null;
+}
+
 export interface WalletInfo {
   connector?: AbstractConnector
   name: string

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -26,3 +26,5 @@ export const addSerializedPair = createAction<{ serializedPair: SerializedPair }
 export const removeSerializedPair = createAction<{ chainId: number; tokenAAddress: string; tokenBAddress: string }>(
   'user/removeSerializedPair'
 )
+
+export const updateUserWallet = createAction<{ userWallet: string }>('user/updateUserWallet')

--- a/src/state/user/actions.ts
+++ b/src/state/user/actions.ts
@@ -1,5 +1,7 @@
 import { createAction } from '@reduxjs/toolkit'
 
+import { UserWallet } from '../../constants'
+
 export interface SerializedToken {
   chainId: number
   address: string
@@ -27,4 +29,4 @@ export const removeSerializedPair = createAction<{ chainId: number; tokenAAddres
   'user/removeSerializedPair'
 )
 
-export const updateUserWallet = createAction<{ userWallet: string }>('user/updateUserWallet')
+export const updateUserWallet = createAction<{ userWallet: UserWallet | null }>('user/updateUserWallet')

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -17,8 +17,12 @@ import {
   updateUserDarkMode,
   updateUserDeadline,
   updateUserExpertMode,
-  updateUserSlippageTolerance
+  updateUserSlippageTolerance,
+  updateUserWallet,
 } from './actions'
+
+//import { AbstractWallet } from '../../wallets/AbstractWallet';
+import { oneWallet, mathWallet } from '../../connectors'
 
 function serializeToken(token: Token): SerializedToken {
   return {
@@ -159,6 +163,39 @@ export function usePairAdder(): (pair: Pair) => void {
     },
     [dispatch]
   )
+}
+
+export function useUserWallet(): [string, (wallet: string) => void] {
+  const dispatch = useDispatch<AppDispatch>()
+  const userWallet = useSelector<AppState, AppState['user']['userWallet']>(state => {
+    return state.user.userWallet
+  })
+
+  const setUserWallet = useCallback(
+    (userWallet: string) => {
+      dispatch(updateUserWallet({ userWallet }))
+    },
+    [dispatch]
+  )
+
+  return [userWallet, setUserWallet]
+}
+
+export function useUserActiveWallet(): any | null {
+  const userWallet = useSelector<AppState, AppState['user']['userWallet']>(state => {
+    return state.user.userWallet
+  })
+
+  switch (userWallet.toLowerCase()) {
+    case 'onewallet': {
+      return oneWallet;
+    }
+    case 'mathwallet': {
+      return mathWallet;
+    }
+    default:
+      return null;
+  }
 }
 
 /**

--- a/src/state/user/hooks.tsx
+++ b/src/state/user/hooks.tsx
@@ -3,7 +3,7 @@ import { Pair, Token } from '@swoop-exchange/sdk'
 import flatMap from 'lodash.flatmap'
 import { useCallback, useMemo } from 'react'
 import { shallowEqual, useDispatch, useSelector } from 'react-redux'
-import { BASES_TO_TRACK_LIQUIDITY_FOR, PINNED_PAIRS } from '../../constants'
+import { BASES_TO_TRACK_LIQUIDITY_FOR, PINNED_PAIRS, UserWallet } from '../../constants'
 
 import { useActiveWeb3React } from '../../hooks'
 import { useAllTokens } from '../../hooks/Tokens'
@@ -165,14 +165,14 @@ export function usePairAdder(): (pair: Pair) => void {
   )
 }
 
-export function useUserWallet(): [string, (wallet: string) => void] {
+export function useUserWallet(): [UserWallet | null, (wallet: UserWallet | null) => void] {
   const dispatch = useDispatch<AppDispatch>()
   const userWallet = useSelector<AppState, AppState['user']['userWallet']>(state => {
     return state.user.userWallet
   })
 
   const setUserWallet = useCallback(
-    (userWallet: string) => {
+    (userWallet: UserWallet | null) => {
       dispatch(updateUserWallet({ userWallet }))
     },
     [dispatch]
@@ -186,7 +186,13 @@ export function useUserActiveWallet(): any | null {
     return state.user.userWallet
   })
 
-  switch (userWallet.toLowerCase()) {
+  if (userWallet == null) {
+    return null;
+  } else if (userWallet.type == null) {
+    return null;
+  }
+
+  switch (userWallet.type.toLowerCase()) {
     case 'onewallet': {
       return oneWallet;
     }

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -1,4 +1,4 @@
-import { INITIAL_ALLOWED_SLIPPAGE, DEFAULT_DEADLINE_FROM_NOW } from '../../constants'
+import { INITIAL_ALLOWED_SLIPPAGE, DEFAULT_DEADLINE_FROM_NOW, UserWallet } from '../../constants'
 import { createReducer } from '@reduxjs/toolkit'
 import { updateVersion } from '../global/actions'
 import {
@@ -13,7 +13,7 @@ import {
   updateUserExpertMode,
   updateUserSlippageTolerance,
   updateUserDeadline,
-  updateUserWallet
+  updateUserWallet,
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -48,7 +48,7 @@ export interface UserState {
 
   timestamp: number
 
-  userWallet: string
+  userWallet: UserWallet | null
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -64,7 +64,7 @@ export const initialState: UserState = {
   tokens: {},
   pairs: {},
   timestamp: currentTimestamp(),
-  userWallet: ''
+  userWallet: {type: '', address: '', bech32Address: ''}
 }
 
 export default createReducer(initialState, builder =>

--- a/src/state/user/reducer.ts
+++ b/src/state/user/reducer.ts
@@ -12,7 +12,8 @@ import {
   updateUserDarkMode,
   updateUserExpertMode,
   updateUserSlippageTolerance,
-  updateUserDeadline
+  updateUserDeadline,
+  updateUserWallet
 } from './actions'
 
 const currentTimestamp = () => new Date().getTime()
@@ -46,6 +47,8 @@ export interface UserState {
   }
 
   timestamp: number
+
+  userWallet: string
 }
 
 function pairKey(token0Address: string, token1Address: string) {
@@ -60,7 +63,8 @@ export const initialState: UserState = {
   userDeadline: DEFAULT_DEADLINE_FROM_NOW,
   tokens: {},
   pairs: {},
-  timestamp: currentTimestamp()
+  timestamp: currentTimestamp(),
+  userWallet: ''
 }
 
 export default createReducer(initialState, builder =>
@@ -98,6 +102,10 @@ export default createReducer(initialState, builder =>
     })
     .addCase(updateUserDeadline, (state, action) => {
       state.userDeadline = action.payload.userDeadline
+      state.timestamp = currentTimestamp()
+    })
+    .addCase(updateUserWallet, (state, action) => {
+      state.userWallet = action.payload.userWallet
       state.timestamp = currentTimestamp()
     })
     .addCase(addSerializedToken, (state, { payload: { serializedToken } }) => {

--- a/src/wallets/AbstractWallet.ts
+++ b/src/wallets/AbstractWallet.ts
@@ -5,7 +5,7 @@ export abstract class AbstractWallet {
   public isAuthorized: boolean;
   public redirectUrl!: string;
   public extension: any;
-  public sessionType: 'onewallet' | 'mathwallet' | 'ledger' | 'wallet' | null;
+  public sessionType: 'onewallet' | 'mathwallet' | 'ledger' | 'wallet' | '';
   public address: string | null;
   public base16Address: string | null;
 
@@ -14,7 +14,7 @@ export abstract class AbstractWallet {
     this.client = client;
 
     this.isAuthorized = false;
-    this.sessionType = null;
+    this.sessionType = '';
     this.address = null;
     this.base16Address = null;
   }

--- a/src/wallets/mathwallet.ts
+++ b/src/wallets/mathwallet.ts
@@ -54,7 +54,7 @@ export class MathWallet extends AbstractWallet {
       return this.mathwallet
         .forgetIdentity()
         .then(() => {
-          this.sessionType = null;
+          this.sessionType = '';
           this.address = null;
           this.base16Address = null;
           this.isAuthorized = false;

--- a/src/wallets/onewallet.ts
+++ b/src/wallets/onewallet.ts
@@ -55,7 +55,7 @@ export class OneWallet extends AbstractWallet {
       return this.onewallet
         .forgetIdentity()
         .then(() => {
-          this.sessionType = null;
+          this.sessionType = '';
           this.address = null;
           this.base16Address = null;
           this.isAuthorized = false;


### PR DESCRIPTION
This is a continuation of ripping out web3-react to support OneWallet & MathWallet.

I've added global React hooks `useUserWallet` & `useUserActiveWallet` that is used to control the state of the wallets.

Using this PR users can:

- Authenticate multiple wallets (OneWallet & MathWallet)
- Disconnect wallet sessions
- Switch between wallets
- See the current active wallet (it displays the base16 address now - there's some kind of validation for 0x addresses, will take a look at this next)